### PR TITLE
adds tree-finder-breadcrumbs custom element, adds optional breadcrumbs to top of tree-finder elements

### DIFF
--- a/packages/tree-finder/package.json
+++ b/packages/tree-finder/package.json
@@ -37,7 +37,8 @@
     "webpack:watch": "webpack --color --watch"
   },
   "dependencies": {
-    "regular-table": "^0.2.1"
+    "regular-table": "^0.2.1",
+    "rxjs": "^6.6.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",

--- a/packages/tree-finder/src/breadcrumbs.ts
+++ b/packages/tree-finder/src/breadcrumbs.ts
@@ -21,7 +21,7 @@ export class TreeFinderBreadcrumbsElement extends HTMLElement {
   create_shadow_dom() {
     this.attachShadow({mode: "open"});
 
-    const crumbsSlot = `<slot"></slot>`;
+    const crumbsSlot = `<slot></slot>`;
 
     this.shadowRoot!.innerHTML = Tag.html`
       <style>

--- a/packages/tree-finder/src/breadcrumbs.ts
+++ b/packages/tree-finder/src/breadcrumbs.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Max Klein
+ *
+ * This file is part of the tree-finder library, distributed under the terms of
+ * the BSD 3 Clause license. The full license can be found in the LICENSE file.
+ */
+import { Tag, Tree } from "./util";
+
+export class TreeFinderBreadcrumbsElement extends HTMLElement {
+  connectedCallback() {
+    if (!this._initialized) {
+      this.create_shadow_dom();
+      this._initialized = true;
+    }
+  }
+
+  async init(path: string[]) {
+    this.innerHTML = Tree.breadcrumbsSpans(path);
+  }
+
+  create_shadow_dom() {
+    this.attachShadow({mode: "open"});
+
+    const crumbsSlot = `<slot"></slot>`;
+
+    this.shadowRoot!.innerHTML = Tag.html`
+      <style>
+      </style>
+      <div class="tf-breadcrumbs-top">
+        ${crumbsSlot}
+      </div>
+    `;
+
+    [this.shadowSheet, this.top] = this.shadowRoot!.children as any as [StyleSheet,HTMLElement];
+  }
+
+  protected shadowSheet: StyleSheet;
+  protected top: HTMLElement;
+
+  private _initialized: boolean = false;
+}

--- a/packages/tree-finder/src/breadcrumbs.ts
+++ b/packages/tree-finder/src/breadcrumbs.ts
@@ -25,6 +25,10 @@ export class TreeFinderBreadcrumbsElement extends HTMLElement {
 
     this.shadowRoot!.innerHTML = Tag.html`
       <style>
+        .tf-breadcrumbs-top {
+          display: flex;
+          align-items: flex-start;
+        }
       </style>
       <div class="tf-breadcrumbs-top">
         ${crumbsSlot}

--- a/packages/tree-finder/src/content.ts
+++ b/packages/tree-finder/src/content.ts
@@ -55,6 +55,10 @@ export class Content<T extends IContentRow> {
     return this._isOpen;
   }
 
+  get name() {
+    return (this.row.path && this.row.path.length) ? this.row.path[this.row.path.length - 1] : "";
+  }
+
   readonly isDir: boolean;
   readonly row: T;
 

--- a/packages/tree-finder/src/grid.ts
+++ b/packages/tree-finder/src/grid.ts
@@ -71,7 +71,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
       // column/row_headers: string[] -> arrays of path parts that get displayed as the first value in each col/row. Length > 1 implies a tree structure
       column_headers: this.model.columns.map(col => [col]),
       row_headers: this.model.contents.slice(start_row, end_row).map(x => {
-        return [Tree.headerHtml({
+        return [Tree.rowHeaderSpan({
           isDir: x.isDir,
           isOpen: x.isOpen,
           path: x.getPathAtDepth(this.model.pathDepth),

--- a/packages/tree-finder/src/index.ts
+++ b/packages/tree-finder/src/index.ts
@@ -15,29 +15,21 @@ import "../style/grid/index.less";
 
 declare global {
   interface Document {
+    createElement<T extends IContentRow>(tagName: "tree-finder", options?: ElementCreationOptions): TreeFinderPanelElement<T>;
     createElement(tagName: "tree-finder-breadcrumbs", options?: ElementCreationOptions): TreeFinderBreadcrumbsElement;
-  }
-  interface CustomElementRegistry {
-    get(name: "tree-finder-breadcrumbs"): typeof TreeFinderBreadcrumbsElement;
-  }
-
-  interface Document {
     createElement<T extends IContentRow>(tagName: "tree-finder-grid", options?: ElementCreationOptions): TreeFinderGridElement<T>;
   }
-  interface CustomElementRegistry {
-    get(name: "tree-finder-grid"): typeof TreeFinderGridElement;
-  }
 
-  interface Document {
-    createElement<T extends IContentRow>(tagName: "tree-finder", options?: ElementCreationOptions): TreeFinderPanelElement<T>;
-  }
   interface CustomElementRegistry {
     get(name: "tree-finder"): typeof TreeFinderPanelElement;
+    get(name: "tree-finder-breadcrumbs"): typeof TreeFinderBreadcrumbsElement;
+    get(name: "tree-finder-grid"): typeof TreeFinderGridElement;
   }
 }
 
-customElements.define("tree-finder-grid", TreeFinderGridElement);
 customElements.define("tree-finder", TreeFinderPanelElement);
+customElements.define("tree-finder-breadcrumbs", TreeFinderBreadcrumbsElement);
+customElements.define("tree-finder-grid", TreeFinderGridElement);
 
 export * from "./content";
 export * from "./panel";

--- a/packages/tree-finder/src/index.ts
+++ b/packages/tree-finder/src/index.ts
@@ -7,12 +7,20 @@
 import "regular-table";
 
 import { IContentRow } from "./content";
+import { TreeFinderBreadcrumbsElement } from "./breadcrumbs";
 import { TreeFinderGridElement } from "./grid";
 import { TreeFinderPanelElement } from "./panel";
 
 import "../style/grid/index.less";
 
 declare global {
+  interface Document {
+    createElement(tagName: "tree-finder-breadcrumbs", options?: ElementCreationOptions): TreeFinderBreadcrumbsElement;
+  }
+  interface CustomElementRegistry {
+    get(name: "tree-finder-breadcrumbs"): typeof TreeFinderBreadcrumbsElement;
+  }
+
   interface Document {
     createElement<T extends IContentRow>(tagName: "tree-finder-grid", options?: ElementCreationOptions): TreeFinderGridElement<T>;
   }

--- a/packages/tree-finder/src/index.ts
+++ b/packages/tree-finder/src/index.ts
@@ -12,6 +12,7 @@ import { TreeFinderGridElement } from "./grid";
 import { TreeFinderPanelElement } from "./panel";
 
 import "../style/grid/index.less";
+import "../style/breadcrumbs.less";
 
 declare global {
   interface Document {

--- a/packages/tree-finder/src/model.ts
+++ b/packages/tree-finder/src/model.ts
@@ -4,6 +4,8 @@
  * This file is part of the tree-finder library, distributed under the terms of
  * the BSD 3 Clause license. The full license can be found in the LICENSE file.
  */
+import { BehaviorSubject } from "rxjs/internal/BehaviorSubject";
+
 import { Content, IContentRow } from "./content";
 import { SortStates, sortContentRoot} from "./sort";
 
@@ -23,6 +25,7 @@ export class ContentsModel<T extends IContentRow> {
 
     if (!crumbIx) {
       this._crumbs = [];
+      this.crumbSubject.next(this._crumbs.map(x => x.name));
       return;
     }
 
@@ -34,7 +37,9 @@ export class ContentsModel<T extends IContentRow> {
   setRoot(root: T) {
     this._sortStates = new SortStates();
     this._root = new Content(root);
+
     this._crumbs.push(this._root);
+    this.crumbSubject.next(this._crumbs.map(x => x.name));
 
     this.initColumns();
 
@@ -121,6 +126,8 @@ export class ContentsModel<T extends IContentRow> {
   get ixByColumn() {
     return this._ixByColumn;
   }
+
+  readonly crumbSubject = new BehaviorSubject([] as string[]);
 
   protected _columns: (keyof T)[];
   protected _contents: Content<T>[];

--- a/packages/tree-finder/src/model.ts
+++ b/packages/tree-finder/src/model.ts
@@ -11,14 +11,31 @@ export class ContentsModel<T extends IContentRow> {
   constructor(root?: T, options: Partial<ContentsModel.IOptions<T>> = {}) {
     this.options = options;
 
+    this.reset();
+
     if (root) {
       this.setRoot(root);
     }
   }
 
+  reset(crumbIx?: number) {
+    this._contents = [];
+
+    if (!crumbIx) {
+      this._crumbs = [];
+      return;
+    }
+
+    const rootContent = this._crumbs[crumbIx];
+    this._crumbs = this._crumbs.slice(0, crumbIx);
+    this.setRoot(rootContent.row);
+  }
+
   setRoot(root: T) {
     this._sortStates = new SortStates();
     this._root = new Content(root);
+    this._crumbs.push(this._root);
+
     this.initColumns();
 
     // fetch root's children and mark it as open
@@ -106,7 +123,8 @@ export class ContentsModel<T extends IContentRow> {
   }
 
   protected _columns: (keyof T)[];
-  protected _contents: Content<T>[] = [];
+  protected _contents: Content<T>[];
+  protected _crumbs: Content<T>[];
   protected _root: Content<T>;
   protected _sortStates: SortStates<T>;
 

--- a/packages/tree-finder/src/panel.ts
+++ b/packages/tree-finder/src/panel.ts
@@ -50,6 +50,10 @@ export class TreeFinderPanelElement<T extends IContentRow> extends HTMLElement {
     }
 
     this.model = new ContentsModel(root, modelOptions);
+
+    this.model.crumbSubject.subscribe({
+      next: x => this.breadcrumbs.init(x),
+    });
     this.grid.init(this.model, gridOptions);
 
     await this.draw();

--- a/packages/tree-finder/src/panel.ts
+++ b/packages/tree-finder/src/panel.ts
@@ -5,6 +5,7 @@
  * the BSD 3 Clause license. The full license can be found in the LICENSE file.
  */
 import { IContentRow } from "./content";
+import { TreeFinderBreadcrumbsElement } from "./breadcrumbs"
 import { ContentsModel } from "./model";
 import { TreeFinderGridElement } from "./grid";
 import { Tag } from "./util";
@@ -21,12 +22,12 @@ export class TreeFinderPanelElement<T extends IContentRow> extends HTMLElement {
 
   clear() {
     this.innerHTML = Tag.html`
-      <div class="tf-panel-breadcrumbs" slot="breadcrumbs"></div>
+      <tree-finder-breadcrumbs class="tf-panel-breadcrumbs" slot="breadcrumbs"></tree-finder-breadcrumbs>
       <div class="tf-panel-filter" slot="filter"></div>
       <tree-finder-grid class="tf-panel-grid" slot="grid"></tree-finder-grid>
     `;
 
-    [this.breadcrumbs, this.filter, this.grid] = this.children as any as [HTMLElement, HTMLElement, TreeFinderGridElement<T>];
+    [this.breadcrumbs, this.filter, this.grid] = this.children as any as [TreeFinderBreadcrumbsElement, HTMLElement, TreeFinderGridElement<T>];
   }
 
   async init(root: T, options: Partial<TreeFinderPanelElement.IOptions<T> & ContentsModel.IOptions<T> & TreeFinderGridElement.IOptions<T>> = {}) {
@@ -87,7 +88,7 @@ export class TreeFinderPanelElement<T extends IContentRow> extends HTMLElement {
   protected filterContainer: HTMLElement;
   protected gridContainer: HTMLElement;
 
-  protected breadcrumbs: HTMLElement;
+  protected breadcrumbs: TreeFinderBreadcrumbsElement;
   protected filter: HTMLElement;
   protected grid: TreeFinderGridElement<T>;
 

--- a/packages/tree-finder/src/util.ts
+++ b/packages/tree-finder/src/util.ts
@@ -127,14 +127,12 @@ export namespace Tree {
     return treeTemplate.content.firstChild as HTMLSpanElement;
   }
 
-  export function breadcrumbsSpans(path: string[]): HTMLSpanElement[] {
-    treeTemplate.innerHTML = [
+  export function breadcrumbsSpans(path: string[]): string {
+    return [
       `<span class="tf-breadcrumbs-icon tf-breadcrumbs-dir-icon"></span>`,
       ...path.slice(1),
     ]
     .map(x => `<span class="tf-breadcrumbs-crumb">${x}</span>`)
     .join(`<span class="tf-breadcrumbs-separator">/</span>`);
-
-    return treeTemplate.content.children as any as HTMLSpanElement[];
   }
 }

--- a/packages/tree-finder/src/util.ts
+++ b/packages/tree-finder/src/util.ts
@@ -128,11 +128,10 @@ export namespace Tree {
   }
 
   export function breadcrumbsSpans(path: string[]): string {
-    return [
-      `<span class="tf-breadcrumbs-icon tf-breadcrumbs-dir-icon"></span>`,
-      ...path.slice(1),
-    ]
-    .map(x => `<span class="tf-breadcrumbs-crumb">${x}</span>`)
-    .join(`<span class="tf-breadcrumbs-separator">/</span>`);
+    return `<div class="tf-breadcrumbs-home"><span class="tf-breadcrumbs-icon tf-breadcrumbs-dir-icon"></span><span>/</span></div>` + (
+      [...path.slice(1),]
+      .map(x => `<span class="tf-breadcrumbs-crumb">${x}</span>`)
+      .join(`<span class="tf-breadcrumbs-separator">/</span>`)
+    );
   }
 }

--- a/packages/tree-finder/src/util.ts
+++ b/packages/tree-finder/src/util.ts
@@ -5,6 +5,7 @@
  * the BSD 3 Clause license. The full license can be found in the LICENSE file.
  */
 import { MetaData, RegularTableElement } from "regular-table";
+import {Template} from "webpack";
 
 export namespace Random {
   export function bool() {
@@ -106,7 +107,7 @@ export namespace Tag {
 export namespace Tree {
   const treeTemplate = document.createElement("template");
 
-  function headerLevelsHtml({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}) {
+  function rowHeaderLevelsHtml({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}) {
     const tree_levels = path.slice(1).map(() => '<span class="rt-tree-group"></span>');
     if (isDir) {
       const group_icon = isOpen ? "remove" : "add";
@@ -117,12 +118,23 @@ export namespace Tree {
     return tree_levels.join("");
   }
 
-  export function headerHtml({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}) {
-    const tree_levels = headerLevelsHtml({isDir, isOpen, path});
+  export function rowHeaderSpan({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}): HTMLSpanElement {
+    const tree_levels = rowHeaderLevelsHtml({isDir, isOpen, path});
     const header_classes = !isDir ? "rt-group-name rt-group-leaf" : "rt-group-name";
     const header_text = path.length === 0 ? "TOTAL" : path[path.length - 1];
 
     treeTemplate.innerHTML = `<span class="rt-tree-container">${tree_levels}<span class="${header_classes}">${header_text}</span></span>`;
-    return treeTemplate.content.firstChild;
+    return treeTemplate.content.firstChild as HTMLSpanElement;
+  }
+
+  export function breadcrumbsSpans(path: string[]): HTMLSpanElement[] {
+    treeTemplate.innerHTML = [
+      `<span class="tf-breadcrumbs-icon tf-breadcrumbs-dir-icon"></span>`,
+      ...path.slice(1),
+    ]
+    .map(x => `<span class="tf-breadcrumbs-crumb">${x}</span>`)
+    .join(`<span class="tf-breadcrumbs-separator">/</span>`);
+
+    return treeTemplate.content.children as any as HTMLSpanElement[];
   }
 }

--- a/packages/tree-finder/style/breadcrumbs.less
+++ b/packages/tree-finder/style/breadcrumbs.less
@@ -5,10 +5,23 @@
 // the BSD 3 Clause license. The full license can be found in the LICENSE file.
 //
 
+tree-finder-breadcrumbs {
+  font-family: var(--tf-font-family);
+  font-size: var(--tf-font-size);
+}
+
 .tf-breadcrumbs-icon {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 16px;
   content: "";
   min-width: 16px;
   min-height: 16px;
+}
+
+.tf-breadcrumbs-home {
+  display: flex;
+  align-items: flex-start;
 }
 
 .tf-breadcrumbs-dir-icon {

--- a/packages/tree-finder/style/grid/index.less
+++ b/packages/tree-finder/style/grid/index.less
@@ -16,6 +16,9 @@
 }
 
 tree-finder .tf-panel-grid {
+  font-family: var(--tf-font-family);
+  font-size: var(--tf-font-size);
+
   @import "./base.less";
   @import "./header.less";
   @import "./row.less";

--- a/packages/tree-finder/style/grid/row.less
+++ b/packages/tree-finder/style/grid/row.less
@@ -6,6 +6,8 @@
 //
 
 .tf-grid-filetype-icon:before {
+  background-size: 16px;
+  background-repeat: no-repeat;
   content: "";
   float: left;
   margin-right: 5px;
@@ -20,4 +22,15 @@
 
 .tf-grid-text-icon:before {
   background-image: var(--tf-text-icon);
+}
+
+tr:hover:not(.tf-mod-select) {
+  background: var(--tf-row-hover-background);
+  color: var(--tf-row-hover-color);
+  opacity: 1;
+}
+
+tr.tf-mod-select {
+  background: var(--tf-select-background);
+  color: var(--tf-select-color);
 }

--- a/packages/tree-finder/style/theme/material.css
+++ b/packages/tree-finder/style/theme/material.css
@@ -13,10 +13,16 @@
   --tf-icon-font: "Material Icons";
   --tf-row-hover-background: #eee;
   --tf-row-hover-color: #333;
+
+  --tf-select-background: #2196ee;
+  --tf-select-color: #eee;
+
+  --tf-font-family: "Open Sans";
+  --tf-font-size: 12px;
 }
 
 tree-finder .tf-panel-grid {
-  padding-top: 12px;
+  padding-top: 30px;
   padding-left: 12px;
   padding-bottom: 0;
   padding-right: 0;
@@ -108,21 +114,12 @@ tree-finder .tf-panel-grid td,
 tree-finder .tf-panel-grid th,
 :host th {
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--tf-font-size);
   padding-right: 5px;
   padding-left: 5px;
   padding-top: 0px;
   padding-bottom: 0px;
   height: 19px;
-}
-tree-finder .tf-panel-grid tbody:hover tr:hover,
-:host tbody:hover tr:hover {
-  background: var(--tf-row-hover-background);
-  opacity: 1;
-}
-tree-finder .tf-panel-grid tbody:hover tr:hover,
-:host tbody:hover tr:hover {
-  color: var(--tf-row-hover-color);
 }
 tree-finder .tf-panel-grid table *,
 :host table * {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6907,11 +6907,6 @@ regexp.prototype.flags@^1.2.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regular-table@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.1.6.tgz#99f4ff3211dd4521e0f8ce9fa99a58146d3d0b79"
-  integrity sha512-6i2IMAxBE6kNycPpEEhAbNOrBMm/yFmLeAtz3rbg9+VrKq8uyLuuJlbplHOEnZkweeIn1o5bXmdke5UCtT+NhQ==
-
 regular-table@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.2.1.tgz#af3d1efeeebe7d8071eda4e0dda689b4683ae156"
@@ -8001,13 +7996,6 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
-
-tree-finder@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/tree-finder/-/tree-finder-0.0.2.tgz#667eb4aad104106c3f2cb3f6daf213d95dc55607"
-  integrity sha512-rfGhA/8NaHnX2CxqOzpbNW6r9UlJM14vJQscmaBb/aX6DS0c8UheH//YfVuuW4Cz2qG57Yoke3QxrgjlR0ENaw==
-  dependencies:
-    regular-table "^0.1.6"
 
 trim-newlines@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7096,7 +7096,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.4.0:
+rxjs@^6.4.0, rxjs@^6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==


### PR DESCRIPTION
closes #9

Todo:

- [x] add support for breadcrumbs to `ContentsModel`
- [x] add factory function for breadcrumbs html contents
- [x] add `tree-finder-breadcrumbs` custom element and `TreeFinderBreadcrumbsElement` implementation
- [ ] add option to add `tree-finder-breadcrumbs` to top of `tree-finder` panel
