### PR TITLE
filter improvement: round one

### DIFF
--- a/packages/tree-finder/src/content.ts
+++ b/packages/tree-finder/src/content.ts
@@ -14,6 +14,12 @@ export interface IContentRow {
   getChildren?: () => Promise<IContentRow[]>;
 }
 
+interface IContentDirRow {
+  path: Path;
+  kind: "dir";
+  getChildren: () => Promise<IContentRow[]>;
+}
+
 export class Content<T extends IContentRow> {
   constructor(row: T) {
     this.isDir = row.kind === "dir";
@@ -30,7 +36,7 @@ export class Content<T extends IContentRow> {
   }
 
   async getChildren() {
-    if (!this.isDir) {
+    if (!Content.isContentDirRow(this.row)) {
       return;
     }
 
@@ -39,7 +45,7 @@ export class Content<T extends IContentRow> {
     }
 
     if (this._dirtyChildren) {
-      this._cache = (await this.row.getChildren!()).map((c: T) => new Content<T>(c)) ?? [];
+      this._cache = (await this.row.getChildren()).map((c: T) => new Content<T>(c)) ?? [];
 
       this._dirtyChildren = false;
       this._dirtyFilter = true;
@@ -148,4 +154,8 @@ export class Content<T extends IContentRow> {
 export namespace Content {
   export type Filterer<T extends IContentRow> = (c: Content<T>) => boolean;
   export type Sorter<T extends IContentRow> = (l: Content<T>, r: Content<T>) => number;
+
+  export function isContentDirRow<T extends IContentRow, U extends IContentDirRow>(x: T | U): x is U {
+    return x.kind === "dir";
+  }
 }

--- a/packages/tree-finder/src/element/grid.ts
+++ b/packages/tree-finder/src/element/grid.ts
@@ -88,6 +88,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
           isDir: x.isDir,
           isOpen: x.isExpand,
           path: x.getPathAtDepth(this.model.pathDepth),
+          relative: this.model.filterPatterns.any,
         })];
       }),
 

--- a/packages/tree-finder/src/model.ts
+++ b/packages/tree-finder/src/model.ts
@@ -118,7 +118,7 @@ export class ContentsModel<T extends IContentRow> {
       this._parentMap.set(c.row, content.row);
     }
 
-    const [nodeContents, _] = filterSortContentRoot({root: this._contents[rix], filterPatterns: this._filterPatterns, sortStates: this._sortStates});
+    const [nodeContents, _] = filterSortContentRoot({root: content, filterPatterns: this._filterPatterns, sortStates: this._sortStates, pathDepth: this.pathDepth});
     this._contents.splice(rix + 1, 0, ...nodeContents);
   }
 
@@ -140,7 +140,9 @@ export class ContentsModel<T extends IContentRow> {
     const {col, multisort} = props;
     await this._root.expand(this._options.doRefetch);
 
-    [this._contents, this._sortStates] = sortContentRoot({root: this._root, sortStates: this._sortStates, col, multisort});
+    [this._contents, this._sortStates] = filterSortContentRoot({root: this._root, filterPatterns: this._filterPatterns, sortStates: this._sortStates, col, multisort});
+
+    this.drawSub.next(true);
   }
 
   get columns() {

--- a/packages/tree-finder/src/model.ts
+++ b/packages/tree-finder/src/model.ts
@@ -82,7 +82,7 @@ export class ContentsModel<T extends IContentRow> {
 
     this.initColumns();
 
-    await this._root.expand(this._options.doRefetch);
+    await this._root.expand();
 
     // sort the root's contents and display
     await this.sort();
@@ -100,7 +100,7 @@ export class ContentsModel<T extends IContentRow> {
   async collapse(rix: number) {
     const content = this._contents[rix];
 
-    let npop = content.children?.length ?? 0;
+    let npop = content.nchildren;
     let check_ix = rix + 1 + npop;
     while (this._contents[check_ix++].row.path.length > content.row.path.length) {
       npop++;
@@ -113,19 +113,19 @@ export class ContentsModel<T extends IContentRow> {
   async expand(rix: number) {
     const content = this._contents[rix];
 
-    await content.expand(this._options.doRefetch);
-    for (const c of content.children!) {
-      this._parentMap.set(c.row, content.row);
+    content.expand();
+    for (const child of await content?.getChildren() ?? []) {
+      this._parentMap.set(child.row, content.row);
     }
 
-    const [nodeContents, _] = filterSortContentRoot({root: content, filterPatterns: this._filterPatterns, sortStates: this._sortStates, pathDepth: this.pathDepth});
+    const [nodeContents, _] = await filterSortContentRoot({root: content, filterPatterns: this._filterPatterns, sortStates: this._sortStates, pathDepth: this.pathDepth});
     this._contents.splice(rix + 1, 0, ...nodeContents);
   }
 
   async filter() {
-    await this._root.expand(this._options.doRefetch);
+    await this._root.expand();
 
-    this._contents = filterContentRoot({root: this._root, filterPatterns: this._filterPatterns});
+    this._contents = await filterContentRoot({root: this._root, filterPatterns: this._filterPatterns});
 
     this.drawSub.next(true);
   }
@@ -138,9 +138,9 @@ export class ContentsModel<T extends IContentRow> {
 
   async sort(props: {col?: keyof T, multisort?: boolean} = {}) {
     const {col, multisort} = props;
-    await this._root.expand(this._options.doRefetch);
+    await this._root.expand();
 
-    [this._contents, this._sortStates] = filterSortContentRoot({root: this._root, filterPatterns: this._filterPatterns, sortStates: this._sortStates, col, multisort});
+    [this._contents, this._sortStates] = await filterSortContentRoot({root: this._root, filterPatterns: this._filterPatterns, sortStates: this._sortStates, col, multisort});
 
     this.drawSub.next(true);
   }

--- a/packages/tree-finder/src/model.ts
+++ b/packages/tree-finder/src/model.ts
@@ -100,13 +100,15 @@ export class ContentsModel<T extends IContentRow> {
   async collapse(rix: number) {
     const content = this._contents[rix];
 
-    let npop = content.nchildren;
-    let check_ix = rix + 1 + npop;
-    while (this._contents[check_ix++].row.path.length > content.row.path.length) {
+    let check_ix = rix + 1;
+    let npop = 0;
+
+    while (this._contents[check_ix] && this._contents[check_ix].row.path.length > content.row.path.length) {
+      check_ix++;
       npop++;
     }
-    this._contents.splice(rix + 1, npop);
 
+    this._contents.splice(rix + 1, npop);
     content.close();
   }
 

--- a/packages/tree-finder/src/util.ts
+++ b/packages/tree-finder/src/util.ts
@@ -103,7 +103,7 @@ export namespace Tag {
 export namespace Tree {
   const treeTemplate = document.createElement("template");
 
-  function rowHeaderLevelsHtml({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}) {
+  function rowHeaderLevelsHtml({isDir, isOpen, path = []}: {isDir: boolean, isOpen: boolean, path?: string[]}) {
     const tree_levels = path.slice(1).map(() => '<span class="rt-tree-group"></span>');
     if (isDir) {
       const group_icon = isOpen ? "remove" : "add";
@@ -114,10 +114,11 @@ export namespace Tree {
     return tree_levels.join("");
   }
 
-  export function rowHeaderSpan({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}): HTMLSpanElement {
-    const tree_levels = rowHeaderLevelsHtml({isDir, isOpen, path});
+  export function rowHeaderSpan({isDir, isOpen, path, relative = false}: {isDir: boolean, isOpen: boolean, path: string[], relative?: boolean}): HTMLSpanElement {
+    const tree_levels = rowHeaderLevelsHtml({isDir, isOpen, path: relative ? [] : path});
     const header_classes = !isDir ? "rt-group-name rt-group-leaf" : "rt-group-name";
-    const header_text = path.length === 0 ? "path" : String.normSlash(path[path.length - 1], isDir);
+    const path_parts = relative ? path : [path[path.length - 1]];
+    const header_text = path_parts.map((x, ix) => String.normSlash(x, ix < (path_parts.length - 1) ? true : isDir)).join("");
 
     treeTemplate.innerHTML = `<span class="rt-tree-container">${tree_levels}<span class="${header_classes}">${header_text}</span></span>`;
     return treeTemplate.content.firstChild as HTMLSpanElement;

--- a/packages/tree-finder/src/util.ts
+++ b/packages/tree-finder/src/util.ts
@@ -76,6 +76,22 @@ export namespace RegularTable {
   }
 }
 
+export namespace String {
+  /**
+   * remove all back/slashes from string
+   */
+  export function trimSlash(x: string) {
+    return x.replace(/[\/\\]/g, "");
+  }
+
+  /**
+   * remove all back/slashes, then add a trailing slash if requested to a string
+   */
+  export function normSlash(x: string, trailing: boolean) {
+    return String.trimSlash(x) + (trailing ? "/" : "");
+  }
+}
+
 export namespace Tag {
   export const html = (strings: TemplateStringsArray, ...args: any[]) => strings
     .map((str, i) => [str, args[i]])
@@ -101,7 +117,7 @@ export namespace Tree {
   export function rowHeaderSpan({isDir, isOpen, path}: {isDir: boolean, isOpen: boolean, path: string[]}): HTMLSpanElement {
     const tree_levels = rowHeaderLevelsHtml({isDir, isOpen, path});
     const header_classes = !isDir ? "rt-group-name rt-group-leaf" : "rt-group-name";
-    const header_text = path.length === 0 ? "TOTAL" : path[path.length - 1];
+    const header_text = path.length === 0 ? "path" : String.normSlash(path[path.length - 1], isDir);
 
     treeTemplate.innerHTML = `<span class="rt-tree-container">${tree_levels}<span class="${header_classes}">${header_text}</span></span>`;
     return treeTemplate.content.firstChild as HTMLSpanElement;


### PR DESCRIPTION
- [x] allow path filtering to match against any part of path. Previously was a bit buggy and only matched against first part
- [x] display full relative path in tree for every row when any filter is enabled
- [x] lots more small fixes