### PR TITLE
Bump regular-table to v0.3.0

### DIFF
--- a/examples/html/basic_cdn.html
+++ b/examples/html/basic_cdn.html
@@ -43,7 +43,7 @@
 
 <body>
 
-  <tree-finder></tree-finder>
+  <tree-finder-panel></tree-finder-panel>
 
   <script>
     const N_CHILDREN = 100;
@@ -83,7 +83,7 @@
         path: [],
       });
 
-      const treeFinder = document.getElementsByTagName("tree-finder")[0];
+      const treeFinder = document.getElementsByTagName("tree-finder-panel")[0];
       await treeFinder.init({
         root,
         gridOptions: {

--- a/examples/html/basic_local.html
+++ b/examples/html/basic_local.html
@@ -43,7 +43,7 @@
 
 <body>
 
-  <tree-finder></tree-finder>
+  <tree-finder-panel></tree-finder-panel>
 
   <script>
     const N_CHILDREN = 100;
@@ -83,7 +83,7 @@
         path: [],
       });
 
-      const treeFinder = document.getElementsByTagName("tree-finder")[0];
+      const treeFinder = document.getElementsByTagName("tree-finder-panel")[0];
       await treeFinder.init({
         root,
         gridOptions: {

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "tree-finder": "^0.0.11",
-    "tree-finder-mockcontents": "^0.0.8"
+    "tree-finder-mockcontents": "^0.0.11"
   },
   "devDependencies": {
     "html-webpack-plugin": "^5.0.0",

--- a/packages/tree-finder/package.json
+++ b/packages/tree-finder/package.json
@@ -34,7 +34,7 @@
     "webpack:watch": "webpack --color --watch"
   },
   "dependencies": {
-    "regular-table": "^0.2.1",
+    "regular-table": "^0.3.0",
     "rxjs": "^6.6.3"
   },
   "devDependencies": {

--- a/packages/tree-finder/package.json
+++ b/packages/tree-finder/package.json
@@ -38,7 +38,7 @@
     "rxjs": "^6.6.3"
   },
   "devDependencies": {
-    "@types/react": "^16.9.38",
+    "@types/react": "^17.0.0",
     "@types/resize-observer-browser": "^0.1.5",
     "less": "^4.1.1",
     "rimraf": "^3.0.2",

--- a/packages/tree-finder/src/element/grid.ts
+++ b/packages/tree-finder/src/element/grid.ts
@@ -23,7 +23,9 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
   async init(model: ContentsModel<T>, options: TreeFinderGridElement.IOptions<T> = {}) {
     this.model = model;
     this.options = options;
-    this.setDataListener((x0, y0, x1, y1) => this.dataListener(x0, y0, x1, y1) as any);
+    // (this as any).setDataListener((x0: any, y0: any, x1: any, y1: any) => {return this.dataListener(x0, y0, x1, y1)}, {virtual_mode: "horizontal"});
+    (this as any).setDataListener(this.dataListener.bind(this), {virtual_mode: "vertical"});
+    // this.setDataListener((x0, y0, x1, y1) => this.dataListener(x0, y0, x1, y1) as any);
 
     this.model.drawSub.subscribe(async x => {
       if (x) {
@@ -72,8 +74,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
 
   async dataListener(start_col: number, start_row: number, end_col: number, end_row: number) {
     const data: T[keyof T][][] = [];
-    for (let cix = start_col; cix < end_col - 1; cix++) {
-      const column = this.model.columns[cix];
+    for (const column of this.model.columns.slice(start_col, end_col)) {
       const formatter = this.options?.columnFormatters?.[column] ?? (x => x);
       data.push(
         this.model.contents.slice(start_row, end_row).map(content => {

--- a/packages/tree-finder/src/element/grid.ts
+++ b/packages/tree-finder/src/element/grid.ts
@@ -23,9 +23,8 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
   async init(model: ContentsModel<T>, options: TreeFinderGridElement.IOptions<T> = {}) {
     this.model = model;
     this.options = options;
-    // (this as any).setDataListener((x0: any, y0: any, x1: any, y1: any) => {return this.dataListener(x0, y0, x1, y1)}, {virtual_mode: "horizontal"});
-    (this as any).setDataListener(this.dataListener.bind(this), {virtual_mode: "vertical"});
-    // this.setDataListener((x0, y0, x1, y1) => this.dataListener(x0, y0, x1, y1) as any);
+    // TODO: fix the godawful typing of .setDataListener on the regular-table side
+    (this as any).setDataListener(this.dataListener.bind(this), {virtual_mode: this._options.virtual_mode});
 
     this.model.drawSub.subscribe(async x => {
       if (x) {
@@ -309,20 +308,21 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
     return {...this._options};
   }
 
-  set options(options: TreeFinderGridElement.IOptions<T>) {
-    const {
-      columnFormatters = undefined,
-      doWindowResize = false,
-      pathRender = "tree",
-      pathRenderOnFilter = "regular",
-      showFilter = false,
-    } = options;
+  set options({
+    columnFormatters = undefined,
+    doWindowResize = false,
+    pathRender = "tree",
+    pathRenderOnFilter = "regular",
+    showFilter = false,
+    virtual_mode = "vertical",
+  }: TreeFinderGridElement.IOptions<T>) {
     this._options = {
       columnFormatters,
       doWindowResize,
       pathRender,
       pathRenderOnFilter,
       showFilter,
+      virtual_mode,
     }
 
     this.showFilter = this._options.showFilter!;
@@ -377,6 +377,11 @@ export namespace TreeFinderGridElement {
      * if true, add filter inputs to top of each colum
      */
      showFilter?: boolean;
+
+     /**
+      * pass through to .setDataListener "virtual_mode" opt
+      */
+     virtual_mode?: "both" | "horizontal" | "none" | "vertical";
   }
 }
 

--- a/packages/tree-finder/src/element/panel.ts
+++ b/packages/tree-finder/src/element/panel.ts
@@ -108,10 +108,9 @@ export class TreeFinderPanelElement<T extends IContentRow> extends HTMLElement {
     return {...this._options};
   }
 
-  set options(options: TreeFinderPanelElement.IOptions<T>) {
-    const {
-      showFilter = false,
-    } = options;
+  set options({
+    showFilter = false,
+  } : TreeFinderPanelElement.IOptions<T>) {
     this._options = {
       showFilter
     }

--- a/packages/tree-finder/src/model.ts
+++ b/packages/tree-finder/src/model.ts
@@ -188,12 +188,11 @@ export class ContentsModel<T extends IContentRow> {
     return {...this._options};
   }
 
-  set options(options: ContentsModel.IOptions<T>) {
-    const {
-      columnNames,
-      doRefetch = false,
-      needsWidths = false,
-    } = options;
+  set options({
+    columnNames,
+    doRefetch = false,
+    needsWidths = false,
+  }: ContentsModel.IOptions<T>) {
     this._options = {
       columnNames,
       doRefetch,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6494,6 +6494,11 @@ regular-table@^0.2.1:
   resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.2.1.tgz#af3d1efeeebe7d8071eda4e0dda689b4683ae156"
   integrity sha512-24cKRtO/Gkj1p16mvqvkqWCTJSngAtFhYea7bax9XzNjTOy2DAF/507bQE+5zjq/qydfFXOUpTjnAjyIC1E5ug==
 
+regular-table@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.3.0.tgz#86e770b436fe360027f12dcb8d70e129d861f046"
+  integrity sha512-qg1n2fesXmqxmVTeExWvlAlju4r/VrwBDpC53VpPI11cd9XGw8bK28PA/vjlEP+lV0rG68M6V18Ebv/GgEpSpQ==
+
 relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,18 +999,24 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react@^16.9.38":
-  version "16.9.56"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.56.tgz#ea25847b53c5bec064933095fc366b1462e2adf0"
-  integrity sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==
+"@types/react@^17.0.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
   dependencies:
     "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resize-observer-browser@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz#36d897708172ac2380cd486da7a3daf1161c1e23"
   integrity sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
@@ -6489,11 +6495,6 @@ regexp.prototype.flags@^1.2.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regular-table@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.2.1.tgz#af3d1efeeebe7d8071eda4e0dda689b4683ae156"
-  integrity sha512-24cKRtO/Gkj1p16mvqvkqWCTJSngAtFhYea7bax9XzNjTOy2DAF/507bQE+5zjq/qydfFXOUpTjnAjyIC1E5ug==
-
 regular-table@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.3.0.tgz#86e770b436fe360027f12dcb8d70e129d861f046"
@@ -7556,22 +7557,6 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
-
-tree-finder-mockcontents@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/tree-finder-mockcontents/-/tree-finder-mockcontents-0.0.8.tgz#8e7b3ac7e45ffedd2c2cc4542f5659a66cc0a48a"
-  integrity sha512-Ce6EZyK5w/kSRtwX7h4o2O5e6WSSlZ6hWJ86ACRuKavmF1+0miu6cl+ghR7y6p5x4F0CwvA+pRHwXrHlFDHw+Q==
-  dependencies:
-    faker "^5.4.0"
-    tree-finder "^0.0.8"
-
-tree-finder@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/tree-finder/-/tree-finder-0.0.8.tgz#26f5bbc3b1d87a0dac24724c77510d3f6580fd1b"
-  integrity sha512-rRjK9XgaBQyNwEa9QFyJpTCGkeBtBgA5QCh9d07Wcl+dURBIp+qvJ4GAUFLWpG7RXy6K/NNZlL5qBP+0yZWLQA==
-  dependencies:
-    regular-table "^0.2.1"
-    rxjs "^6.6.3"
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The last couple of releases were technically busted (they required a `yarn link` to a local copy of `regular-table` at HEAD), this sets the situation aright