### PR TITLE
refactor layout of dist bundle to include `types/`, remove `lib/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # javascript/typescript
 lib
 node_modules
+types
 
 *.tsbuildinfo
 lerna-debug.log

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "clean": "rimraf dist lib *.tsbuildinfo",
+    "clean": "rimraf dist lib types *.tsbuildinfo",
     "clean:slate": "yarn run clean && rimraf node_modules",
     "start": "webpack serve",
     "start:chromium": "webpack serve --open 'chromium'",

--- a/examples/simple/tsconfig.json
+++ b/examples/simple/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "baseUrl": ".",
+    "declarationDir": "./types",
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/examples/simple/webpack.config.js
+++ b/examples/simple/webpack.config.js
@@ -12,7 +12,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 // To improve build times for large projects enable fork-ts-checker-webpack-plugin
 // const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 
-const { dependencySrcMapRules, stylingRules, svgUrlRules, getOptimization, getResolve, tsRules } = require("../../webpack.rules");
+const { dependencySrcMapRules, stylingRules, svgUrlRules, getContext, getOptimization, getResolve, tsRules } = require("../../webpack.rules");
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -20,7 +20,7 @@ const simpleExampleConfig = {
   devtool: "source-map",
   entry: "src/index.ts",
   watch: false,
-  context: path.resolve(__dirname, "../.."),
+  ...getContext(__dirname),
 
   output: {
     path: path.resolve(__dirname, "dist"),

--- a/packages/tree-finder-mockcontents/package.json
+++ b/packages/tree-finder-mockcontents/package.json
@@ -14,18 +14,19 @@
   "author": "Max Klein <telamonian@users.noreply.github.com>",
   "files": [
     "dist/**/*",
-    "lib/**/*.{d.ts,js,map}",
-    "style/**/*.{css,eot,gif,html,jpg,json,less,png,scss,svg,ttf,woff2}"
+    "src/**/*",
+    "style/**/*.{css,eot,gif,html,jpg,json,less,png,scss,svg,ttf,woff2}",
+    "types/**/*"
   ],
-  "main": "lib/index.js",
+  "main": "dist/tree-finder-mockcontents.js",
+  "types": "types/index.d.ts",
   "sideEffects": [
     "style/**/*"
   ],
-  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "clean": "rimraf dist lib *.tsbuildinfo",
+    "clean": "rimraf dist lib types *.tsbuildinfo",
     "clean:slate": "yarn run clean && rimraf node_modules",
     "postpack": "shx rm README.md LICENSE",
     "prepack": "shx cp ../../README.md . && shx cp ../../LICENSE .",

--- a/packages/tree-finder-mockcontents/tsconfig.json
+++ b/packages/tree-finder-mockcontents/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     // "baseUrl": ".",
+    "declarationDir": "types",
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/packages/tree-finder-mockcontents/webpack.config.js
+++ b/packages/tree-finder-mockcontents/webpack.config.js
@@ -6,7 +6,7 @@
  */
 const path = require("path");
 
-const { dependencySrcMapRules, getOptimization, getResolve, tsRules } = require("../../webpack.rules");
+const { dependencySrcMapRules, getOptimization, getContext, getResolve, tsRules } = require("../../webpack.rules");
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -15,7 +15,7 @@ const treeFinderMockcontentsConfig = {
     "tree-finder-mockcontents": "src/index.ts",
   },
   devtool: "source-map",
-  context: path.resolve(__dirname, "../.."),
+  ...getContext(__dirname),
 
   output: {
     path: path.resolve(__dirname, "dist"),

--- a/packages/tree-finder/package.json
+++ b/packages/tree-finder/package.json
@@ -40,8 +40,6 @@
     "rxjs": "^6.6.3"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0",
-    "@types/resize-observer-browser": "^0.1.5",
     "less": "^4.1.1",
     "rimraf": "^3.0.2",
     "shx": "^0.3.3",
@@ -49,6 +47,9 @@
     "typescript": "^4.2.4",
     "webpack": "^5.21.2",
     "webpack-cli": "^4.5.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tree-finder/package.json
+++ b/packages/tree-finder/package.json
@@ -14,16 +14,17 @@
   "author": "Max Klein <telamonian@users.noreply.github.com>",
   "files": [
     "dist/**/*",
-    "lib/**/*.{d.ts,js,map}",
     "src/**/*",
-    "style/**/*.{css,eot,gif,html,jpg,json,less,png,scss,svg,ttf,woff2}"
+    "style/**/*.{css,eot,gif,html,jpg,json,less,png,scss,svg,ttf,woff2}",
+    "types/**/*"
   ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "dist/tree-finder.js",
+  "style": "dist/tree-finder.css",
+  "types": "types/index.d.ts",
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "clean": "rimraf dist lib *.tsbuildinfo",
+    "clean": "rimraf dist lib types *.tsbuildinfo",
     "clean:slate": "yarn run clean && rimraf node_modules",
     "postpack": "shx rm README.md LICENSE",
     "prepack": "shx cp ../../README.md . && shx cp ../../LICENSE .",

--- a/packages/tree-finder/tsconfig.json
+++ b/packages/tree-finder/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     // "baseUrl": ".",
+    "declarationDir": "types",
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/packages/tree-finder/webpack.config.js
+++ b/packages/tree-finder/webpack.config.js
@@ -8,7 +8,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
 const RemoveEmptyScriptsPlugin = require("webpack-remove-empty-scripts");
 
-const { dependencySrcMapRules, stylingRules, svgUrlRules, getOptimization, getResolve, tsRules } = require("../../webpack.rules");
+const { dependencySrcMapRules, stylingRules, svgUrlRules, getContext, getOptimization, getResolve, tsRules } = require("../../webpack.rules");
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -17,7 +17,8 @@ const treeFinderConfig = {
     "tree-finder": "src/index.ts",
   },
   devtool: "source-map",
-  context: path.resolve(__dirname, "../.."),
+  ...getContext(__dirname),
+  // context: ".",
 
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -74,7 +75,7 @@ const treeFinderStyleConfig = {
     "tree-finder": "style/index.less",
   },
   devtool: "source-map",
-  context: path.resolve(__dirname, "../.."),
+  ...getContext(__dirname),
 
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -116,7 +117,7 @@ const treeFinderThemeConfig = {
     "material": "style/theme/material.css",
   },
   devtool: "source-map",
-  context: path.resolve(__dirname, "../.."),
+  ...getContext(__dirname),
 
   output: {
     path: path.resolve(__dirname, "dist/theme"),

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "allowJs": true,
     "composite": true,
     "declaration": true,
+    "declarationMap": true,
     "incremental": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/webpack.rules.js
+++ b/webpack.rules.js
@@ -123,6 +123,10 @@ const tsRules = [
   },
 ]
 
+const getContext = (dir) => { return {
+  // context: path.resolve(dir),
+};}
+
 const getOptimization = () => { return {
   minimizer: [
     // "...",
@@ -154,6 +158,7 @@ module.exports = {
   stylingRules,
   svgUrlRules,
   tsRules,
+  getContext,
   getOptimization,
   getResolve,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,34 +989,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
-
-"@types/react@^17.0.5":
-  version "17.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.5.tgz#3d887570c4489011f75a3fc8f965bf87d09a1bea"
-  integrity sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/resize-observer-browser@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz#36d897708172ac2380cd486da7a3daf1161c1e23"
-  integrity sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==
-
-"@types/scheduler@*":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
-  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
@@ -2396,11 +2372,6 @@ csso@^4.0.2:
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
-
-csstype@^3.0.2:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
-  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This is a refactor of how the dist bundle (ie the thing i upload to npmjs) is laid out. Basically, I'm adding a `types/` dir, which will contain all of the `.d.ts` typing declarations and all of the `.d.ts.map` typing declaration maps, and removing the `lib/` dir, which contains all of the transpiled `.js` sources. Formerly, I was shipping both the `.js` sources and the `.d.ts` declarations together in `lib/`, and was not including the `.d.ts.map` declaration maps at all.

This is inspired by the [current layout](https://github.com/jupyterlab/lumino/blob/b0d22aeafd079858001923b5c5122b1d84109fed/packages/widgets/tsconfig.json) of the dist bundles for all of the `@lumnio/foo` packages. I like the fact that you don't have to ship the individual `.js` sources this way, just the one actual `tree-finder.js` bundle.