### PR TITLE
Bump regular-table to 0.5.6

### DIFF
--- a/packages/tree-finder/package.json
+++ b/packages/tree-finder/package.json
@@ -37,7 +37,7 @@
     "webpack:watch": "webpack --color --watch"
   },
   "dependencies": {
-    "regular-table": "^0.4.0",
+    "regular-table": "^0.5.6",
     "rxjs": "^6.6.3"
   },
   "devDependencies": {

--- a/packages/tree-finder/src/element/grid.ts
+++ b/packages/tree-finder/src/element/grid.ts
@@ -25,11 +25,11 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
     this.options = options;
     // TODO: apply the setDataListener typing fix below, once regular-table has pulled in the relevant typing fixes upstream
     // this.setDataListener(this.dataListener.bind(this), {virtual_mode: this._options.virtual_mode});
-    (this as any).setDataListener(this.dataListener.bind(this), {virtual_mode: this._options.virtual_mode});
+    this.setDataListener(this.dataListener.bind(this), {virtual_mode: this._options.virtual_mode!});
 
     // run listener initializations only once
     if (!this._initializedListeners) {
-      const [thead, tbody] = [(this as any).table_model.header.table, (this as any).table_model.body.table] as HTMLTableSectionElement[];
+      const [thead, tbody] = [this.table_model.header.table, this.table_model.body.table] as HTMLTableSectionElement[];
 
       this.addStyleListener(() => this.columnHeaderStyleListener())
       this.addStyleListener(() => this.rowStyleListener());
@@ -58,7 +58,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
       // effectively a listener for model.requestDraw invocations
       this.model.drawSub.subscribe(async x => {
         if (x) {
-          (this as any)._resetAutoSize();
+          this._resetAutoSize();
         }
 
         await this.draw();
@@ -168,7 +168,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
       const metadata = RegularTable.metadataFromElement(element, this);
       const rowHeader = metadata?.row_header?.[0] as any as string;
 
-      for (let tr of (this as any).table_model.body.rows as HTMLElement[]) {
+      for (let tr of this.table_model.body.rows as HTMLElement[]) {
         if (tr.childElementCount > (this.model.columns.length + 1)) {
           const th = tr.children[0];
           th.classList.toggle("tf-mod-hover", th.textContent === rowHeader);
@@ -222,7 +222,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
     }
 
     const meta = RegularTable.metadataFromElement(element, this);
-    if (!meta || !RegularTable.columnHeaderClicked(meta) || meta.column_header_y! < (this as any).table_model.header.rows.length - 1) {
+    if (!meta || !RegularTable.columnHeaderClicked(meta) || meta.column_header_y! < this.table_model.header.rows.length - 1) {
       return;
     }
 
@@ -378,7 +378,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
     // there may be spurious rows in table, clamp selected check to contents length
     // TODO: refactor away the any cast once upstream typing fixes are released in regular-table
     // for (let tr of this.table_model.body.rows.slice(0, this.model.contents.length) as HTMLElement[]) {
-    for (let tr of (this as any).table_model.body.rows.slice(0, this.model.contents.length) as HTMLElement[]) {
+    for (let tr of this.table_model.body.rows.slice(0, this.model.contents.length) as HTMLElement[]) {
       const {y} = RegularTable.metadataFromElement(tr.children[0]!, this)!;
 
       if (tr && tr.tagName === "TR") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6482,10 +6482,10 @@ regexp.prototype.flags@^1.2.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regular-table@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.4.0.tgz#41d769e9dcd6a3a6c4d2f4832132562d88a63515"
-  integrity sha512-O44E81FcEnGZjWE/hilOZPODo3dAzbT42cYU8xosicTiAindrwbpkCF6h9seg8Fw1L8eqziugCoODPe5UnarWA==
+regular-table@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/regular-table/-/regular-table-0.5.6.tgz#9b14ab61590ff41c709986ef7ca66ade427bde4b"
+  integrity sha512-lScNtcqjNcPaFYSeDRNsC+t2P/IzYCLKJNls1hBQAyTtWatX94zO87n2ExEPCnbbkKHGYEZ8Uo8Dgvcw34yTQA==
 
 relateurl@^0.2.7:
   version "0.2.7"


### PR DESCRIPTION
 Updated `regular-table` to 0.5.6 to remove unnecessary type casts and improve visibility.