### PR TITLE
Fix blank data fill

### DIFF
--- a/packages/tree-finder/src/element/grid.ts
+++ b/packages/tree-finder/src/element/grid.ts
@@ -88,7 +88,7 @@ export class TreeFinderGridElement<T extends IContentRow> extends RegularTableEl
       // data: object[][] -> array of arrays, each subarray containing all of the visible values for one column
       // .isBlank works around issue with formatting placeholder row that shows up when data is blank
       // TODO: refactor away .isBlank workaround
-      data: this.model.isBlank ? [Array(this.model.columns.length).fill("")] : this._getData(start_col, start_row, end_col, end_row),
+      data: this.model.isBlank ? Array(this.model.columns.length).fill([""]) : this._getData(start_col, start_row, end_col, end_row),
     };
   }
 


### PR DESCRIPTION
When all values are filtered out, currently it will only show 2 columns: the row header ("path") and the first entry in `columns`. 

This PR fixes the dimensions of the blank row such that all columns are still showed even when all rows are filtered out.